### PR TITLE
Re-organize test files, and test using casperJs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ serve
 dist
 .publish
 .idea
-tests.js
+# Compiled tests
+elm.js
+test.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ node_js:
   - "4.1"
 
 install:
-  - npm install -g elm
-  - npm install
+  - npm install -g elm casperjs http-server
   - elm-package install -y
 before_script:
-  - elm-make ./src/elm/TestRunner.elm --output tests.js --yes
-  - curl https://gist.githubusercontent.com/amitaibu/156236d28adddf1c1f16/raw/ebef859fa441f7fc05ae242bf854430c47e5b586/add_jsdom.js > add_jsdom.js
-  - cat add_jsdom.js >> tests.js
-script: node tests.js
+  - elm-make ./src/elm/TestRunner.elm --output test.html
+  - http-server '.' &
+  # Wait for compilation is done.
+  - until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080/test.html); do echo "." && sleep 1; done
+
+script: casperjs test runTests.js

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ elm-package install -y
 
 Execute with `gulp`
 
+## Testing
+
+In order to view the tests on the browser Start elm reactor (`elm-reactor`) and navigate to http://localhost:8000/src/elm/TestRunner.elm

--- a/runTests.js
+++ b/runTests.js
@@ -1,0 +1,18 @@
+var url = 'http://127.0.0.1:8080/test.html';
+
+casper.options.waitTimeout = 60000;
+
+casper.test.begin('Run the Elm tests', function suite(test) {
+  casper.start(url).then(function() {
+    // The test runner doesn't provide a class, so we have to do this query
+    // selector.
+    casper.waitForSelector('body > div > div > div', function() {
+      test.assertSelectorHasText('body > div > div > div', 'All tests passed');
+    });
+
+  });
+
+  casper.run(function() {
+      test.done();
+  });
+});

--- a/src/elm/EventTest.elm
+++ b/src/elm/EventTest.elm
@@ -1,10 +1,7 @@
-module Tests where
+module EventTest where
 
 import ElmTest.Assertion exposing (..)
 import ElmTest.Test exposing (..)
-
-import String
-
 
 import Company exposing (Model)
 import Effects exposing (Effects)
@@ -36,6 +33,6 @@ contextData =
 
 all : Test
 all =
-  suite "All tests"
+  suite "All Event tests"
     [ selectCompanySuite
     ]

--- a/src/elm/LoginTest.elm
+++ b/src/elm/LoginTest.elm
@@ -1,0 +1,62 @@
+module LoginTest where
+
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
+
+import Effects exposing (Effects)
+import Http exposing (..)
+import Login exposing (Model)
+
+
+
+formSuite : Test
+formSuite =
+  let
+    -- Shorthand, to get to the form's properties.
+    name =
+      .loginForm >> .name
+
+    pass =
+      .loginForm >> .pass
+  in
+  suite "Login form suite"
+    [ test "empty name" (assertEqual "" (name <| fst(updateName "")))
+    , test "simple name" (assertEqual "foo" (name <| fst(updateName "foo")))
+    -- Password
+    , test "empty password" (assertEqual "" (pass <| fst(updatePass "")))
+    , test "simple password" (assertEqual "bar" (pass <| fst(updatePass "bar")))
+
+    -- Submit form
+    , test "first submit, status is Fetching" (assertEqual Login.Fetching (.status <| fst(submitForm Login.Init)))
+    , test "first submit, password is reset" (assertEqual "" (pass <| fst(submitForm Login.Init)))
+
+    , test "ongoing submit" (assertEqual Login.Fetching (.status <| fst(submitForm Login.Fetching)))
+    , test "submit done without errors" (assertEqual Login.Fetched (.status <| fst(submitForm Login.Fetched)))
+    , test "submit after another submit with errors" (assertEqual Login.Fetching (.status <| fst(submitForm <| Login.HttpError NetworkError)))
+    ]
+
+updateName : String -> (Login.Model, Effects Login.Action)
+updateName val =
+  Login.update (Login.UpdateName val) Login.initialModel
+
+updatePass : String -> (Login.Model, Effects Login.Action)
+updatePass val =
+  Login.update (Login.UpdatePass val) Login.initialModel
+
+submitForm : Login.Status -> (Login.Model, Effects Login.Action)
+submitForm status =
+  let
+    model =
+      Login.initialModel
+
+    model' =
+      { model | status <- status }
+
+  in
+  Login.update Login.SubmitForm model'
+
+all : Test
+all =
+  suite "All Login tests"
+    [ formSuite
+    ]

--- a/src/elm/TestRunner.elm
+++ b/src/elm/TestRunner.elm
@@ -1,15 +1,20 @@
 module Main where
 
-import Signal exposing (Signal)
+import Graphics.Element exposing (Element)
 
-import ElmTest.Runner.Console exposing (runDisplay)
-import Console exposing (IO, run)
-import Task
+import ElmTest.Test exposing (Test, suite)
+import ElmTest.Runner.Element exposing (runDisplay)
 
-import Tests
+import EventTest
+import LoginTest
 
-console : IO ()
-console = runDisplay Tests.all
+allTests : Test
+allTests =
+  suite "All tests"
+    [ EventTest.all
+    , LoginTest.all
+    ]
 
-port runner : Signal (Task.Task x ())
-port runner = run console
+main : Element
+main =
+  runDisplay allTests


### PR DESCRIPTION
Use casperjs to test, so we don't need to mock the browser's `window` global variable.