### PR TITLE
Adding a Company selection counter

### DIFF
--- a/src/assets/scss/_events-page.scss
+++ b/src/assets/scss/_events-page.scss
@@ -29,8 +29,15 @@
   .companies {
     margin: 10px 0;
     padding: 4px;
-    width: 100%;
+    width: 90%;
     border-radius: 3px;
+    color:$blue;
+    background: white;
+  }
+
+  .selectionCounter {
+    padding: 3px;
+    width: 10%;
     color:$blue;
     background: white;
   }

--- a/src/elm/EventCompanyFilter/Model.elm
+++ b/src/elm/EventCompanyFilter/Model.elm
@@ -1,6 +1,8 @@
 module EventCompanyFilter.Model where
 
-type alias Model = Maybe Int
+type alias Model = {
+ selectedId: Maybe Int, selectionCounter: Int
+}
 
 initialModel : Model
-initialModel = Nothing
+initialModel = {selectedId = Nothing, selectionCounter = -1}

--- a/src/elm/EventCompanyFilter/Test.elm
+++ b/src/elm/EventCompanyFilter/Test.elm
@@ -11,9 +11,9 @@ type alias Model = EventCompanyFilter.Model
 selectCompanySuite : Test
 selectCompanySuite =
   suite "SelectCompany action"
-    [ test "no company" (assertEqual Nothing (selectCompany Nothing))
-    , test "valid company" (assertEqual (Just 1) (selectCompany <| Just 1))
-    , test "invalid company" (assertEqual Nothing (selectCompany <| Just 100))
+    [ test "no company" (assertEqual Nothing (selectCompany Nothing).selectedId) -- just making sure the tests pass.
+    , test "valid company" (assertEqual (Just 1) (selectCompany <| Just 1).selectedId)
+    , test "invalid company" (assertEqual Nothing (selectCompany <| Just 100).selectedId)
     ]
 
 selectCompany : Maybe Int -> Model

--- a/src/elm/EventCompanyFilter/Update.elm
+++ b/src/elm/EventCompanyFilter/Update.elm
@@ -10,12 +10,16 @@ init = initialModel
 
 type Action
   = SelectCompany (Maybe Int)
+  | ResetCounter -- added this to support counter resetting on page init
 
 type alias Model = EventCompanyFilter.Model
 
 update : List Company.Model -> Action -> Model -> Model
 update companies action model =
   case action of
+    ResetCounter -> -- need this to support a differentiation between a page init (that I don't want the counter to count) and a user selection. There's probably a better way to do this
+      {model | selectionCounter = -1}
+
     SelectCompany maybeCompanyId ->
       let
         isValidCompany val =
@@ -23,15 +27,17 @@ update companies action model =
             |> List.filter (\company -> company.id == val)
             |> List.length
 
-
+        increase intNumber  =  
+          intNumber+1
+           
         eventCompanyFilter =
           case maybeCompanyId of
             Just val ->
               -- Make sure the given company ID is a valid one.
               if ((isValidCompany val) > 0)
-                then Just val
-                else Nothing
+                then {model | selectedId = Just val, selectionCounter = increase model.selectionCounter}
+                else {model | selectedId = Nothing} -- don't update counter. (set it to -1?)
             Nothing ->
-              Nothing
+              {model | selectedId = Nothing, selectionCounter = increase model.selectionCounter} 
       in
         eventCompanyFilter

--- a/src/elm/EventCompanyFilter/View.elm
+++ b/src/elm/EventCompanyFilter/View.elm
@@ -63,6 +63,5 @@ companyListForSelect address companies eventCompanyFilter  =
       [ class "companies"
       , value selectedText
       , on "change" targetValue (\str -> Signal.message address <| EventCompanyFilter.Update.SelectCompany <| textToMaybe str)
-   --   , on "input" targetValue (\str -> Signal.message address <| EventCompanyFilter.Update.ResetCounter)
       ]
       (List.map getOption companies')

--- a/src/elm/EventCompanyFilter/View.elm
+++ b/src/elm/EventCompanyFilter/View.elm
@@ -21,13 +21,14 @@ view companies address model =
         , text <| " " ++ "Companies"
         ]
     , companyListForSelect address companies model
+    , span [class "selectionCounter"] [ text (toString model.selectionCounter)]
     ]
 
 companyListForSelect : Signal.Address Action -> List Company.Model -> Model -> Html
 companyListForSelect address companies eventCompanyFilter  =
   let
     selectedText =
-      case eventCompanyFilter of
+      case eventCompanyFilter.selectedId of
         Just id -> toString id
         Nothing -> ""
 
@@ -49,7 +50,7 @@ companyListForSelect address companies eventCompanyFilter  =
 
     -- The selected company ID.
     selectedId =
-      case eventCompanyFilter of
+      case eventCompanyFilter.selectedId of
         Just id ->
           id
         Nothing ->
@@ -62,5 +63,6 @@ companyListForSelect address companies eventCompanyFilter  =
       [ class "companies"
       , value selectedText
       , on "change" targetValue (\str -> Signal.message address <| EventCompanyFilter.Update.SelectCompany <| textToMaybe str)
+   --   , on "input" targetValue (\str -> Signal.message address <| EventCompanyFilter.Update.ResetCounter)
       ]
       (List.map getOption companies')

--- a/src/elm/Pages/Event/Router.elm
+++ b/src/elm/Pages/Event/Router.elm
@@ -8,7 +8,7 @@ delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
   let
     url =
-      case current.eventCompanyFilter of
+      case current.eventCompanyFilter.selectedId of
         Just companyId -> [ toString (companyId) ]
         Nothing -> []
   in

--- a/src/elm/Pages/Event/Update.elm
+++ b/src/elm/Pages/Event/Update.elm
@@ -76,6 +76,7 @@ update context action model =
           case act of
             EventCompanyFilter.Update.SelectCompany maybeCompanyId ->
               maybeCompanyId
+            EventCompanyFilter.Update.ResetCounter -> Nothing
 
       in
         ( { model | eventCompanyFilter = childModel }
@@ -186,6 +187,7 @@ update context action model =
         ( { model | leaflet = childModel }
         , Effects.batch
           [ Task.succeed (GetData maybeCompanyId) |> Effects.task
+          , Task.succeed (ChildEventCompanyFilterAction <| EventCompanyFilter.Update.ResetCounter) |> Effects.task -- resetting the counter on page init
           , Task.succeed (ChildEventCompanyFilterAction <| EventCompanyFilter.Update.SelectCompany maybeCompanyId) |> Effects.task
           ]
         )


### PR DESCRIPTION
@amitaibu 

-- decided to add a counter field to the EventCompanyFilter model and not define a separate model (and view and update) for it.
-- added model, update and view support for the selection counter.
-- fixed the EventCompanyFilter unit tests (but didn't add tests for the selection counter)
-- differentiated between a page init and a user selection by adding a reset counter action, to avoid increasing the counter on page inits. there's probably a better solution for this.
-- need better css definitions for the counter